### PR TITLE
Use nix.conf settings from stable installer

### DIFF
--- a/.github/workflows/kiteless.yml
+++ b/.github/workflows/kiteless.yml
@@ -140,11 +140,12 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          nix run nixpkgs#hello
-          nix profile install nixpkgs#hello
+          nix-channel --update nixpkgs
+          nix-shell -p hello --command hello
+          nix-env --install hello
           hello
-          nix store gc
-          nix run nixpkgs#hello
+          nix-store --gc
+          nix-shell -p hello --command hello
       - name: Test bash
         run: nix-instantiate -E 'builtins.currentTime' --eval
         if: success() || failure()
@@ -247,11 +248,12 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          sudo -i nix run nixpkgs#hello
-          sudo -i nix profile install nixpkgs#hello
-          hello
-          sudo -i nix store gc
-          sudo -i nix run nixpkgs#hello
+          sudo -i nix-channel --update nixpkgs
+          sudo -i nix-shell -p hello --command hello
+          sudo -i nix-env --install hello
+          sudo -i hello
+          sudo -i nix-store --gc
+          sudo -i nix-shell -p hello --command hello
       - name: Test bash
         run: sudo -i nix-instantiate -E 'builtins.currentTime' --eval
         if: success() || failure()
@@ -362,11 +364,12 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          nix run nixpkgs#hello
-          nix profile install nixpkgs#hello
+          nix-channel --update nixpkgs
+          nix-shell -p hello --command hello
+          nix-env --install hello
           hello
-          nix store gc
-          nix run nixpkgs#hello
+          nix-store --gc
+          nix-shell -p hello --command hello
       - name: Test bash
         run: nix-instantiate -E 'builtins.currentTime' --eval
         if: success() || failure()
@@ -475,11 +478,12 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          nix run nixpkgs#hello
-          nix profile install nixpkgs#hello
+          nix-channel --update nixpkgs
+          nix-shell -p hello --command hello
+          nix-env --install hello
           hello
-          nix store gc
-          nix run nixpkgs#hello
+          nix-store --gc
+          nix-shell -p hello --command hello
       - name: Test bash
         run: nix-instantiate -E 'builtins.currentTime' --eval
         if: success() || failure()

--- a/.github/workflows/kiteless.yml
+++ b/.github/workflows/kiteless.yml
@@ -140,7 +140,10 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
+          # TODO this should be part of the installation process
+          echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
           nix-channel --update nixpkgs
+
           nix-shell -p hello --command hello
           nix-env --install hello
           hello
@@ -248,7 +251,10 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
+          # TODO this should be part of the installation process
+          sudo -i sh -c 'echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"'
           sudo -i nix-channel --update nixpkgs
+
           sudo -i nix-shell -p hello --command hello
           sudo -i nix-env --install hello
           sudo -i hello
@@ -364,7 +370,10 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
+          # TODO this should be part of the installation process
+          echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
           nix-channel --update nixpkgs
+
           nix-shell -p hello --command hello
           nix-env --install hello
           hello
@@ -478,7 +487,10 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
+          # TODO this should be part of the installation process
+          echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
           nix-channel --update nixpkgs
+
           nix-shell -p hello --command hello
           nix-env --install hello
           hello

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ build-inputs = ["darwin.apple_sdk.frameworks.Security"]
 build-inputs = ["darwin.apple_sdk.frameworks.Security"]
 
 [features]
-default = ["cli"]
+default = ["cli", "nix-community"]
+nix-community = []
 cli = ["eyre", "color-eyre", "clap", "tracing-subscriber", "tracing-error"]
 diagnostics = ["is_ci"]
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ The `nix-installer` tool is ready to use in a number of environments:
 
 Differing from the current official [Nix](https://github.com/NixOS/nix) installer scripts:
 
-* In `nix.conf`:
-  + the `auto-allocate-uids`, `nix-command` and `flakes` features are enabled
-  + `bash-prompt-prefix` is set
-  + `auto-optimise-store` is set to `true` (On Linux only)
-  * `extra-nix-path` is set to `nixpkgs=flake:nixpkgs`
-  * `auto-allocate-uids` is set to `true`.  (On Linux only)
 * an installation receipt (for uninstalling) is stored at `/nix/receipt.json` as well as a copy of the install binary at `/nix/nix-installer`
 * `nix-channel --update` is not run, `~/.nix-channels` is not provisioned
 * `NIX_SSL_CERT_FILE` is set in the various shell profiles if the `ssl-cert-file` argument is used.

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -35,7 +35,8 @@ impl PlaceNixConfiguration {
         let settings = nix_config.settings_mut();
 
         settings.insert("build-users-group".to_string(), nix_build_group_name);
-        if !cfg!(feature = "nix-community") {
+
+        #[cfg(not(feature = "nix-community"))] {
             let experimental_features = ["nix-command", "flakes", "auto-allocate-uids"];
             match settings.entry("experimental-features".to_string()) {
                 Entry::Occupied(mut slot) => {

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -35,48 +35,50 @@ impl PlaceNixConfiguration {
         let settings = nix_config.settings_mut();
 
         settings.insert("build-users-group".to_string(), nix_build_group_name);
-        let experimental_features = ["nix-command", "flakes", "auto-allocate-uids"];
-        match settings.entry("experimental-features".to_string()) {
-            Entry::Occupied(mut slot) => {
-                let slot_mut = slot.get_mut();
-                for experimental_feature in experimental_features {
-                    if !slot_mut.contains(experimental_feature) {
-                        *slot_mut += " ";
-                        *slot_mut += experimental_feature;
+        if !cfg!(feature = "nix-community") {
+            let experimental_features = ["nix-command", "flakes", "auto-allocate-uids"];
+            match settings.entry("experimental-features".to_string()) {
+                Entry::Occupied(mut slot) => {
+                    let slot_mut = slot.get_mut();
+                    for experimental_feature in experimental_features {
+                        if !slot_mut.contains(experimental_feature) {
+                            *slot_mut += " ";
+                            *slot_mut += experimental_feature;
+                        }
                     }
-                }
-            },
-            Entry::Vacant(slot) => {
-                let _ = slot.insert(experimental_features.join(" "));
-            },
-        };
+                },
+                Entry::Vacant(slot) => {
+                    let _ = slot.insert(experimental_features.join(" "));
+                },
+            };
 
-        // https://github.com/DeterminateSystems/nix-installer/issues/449#issuecomment-1551782281
-        #[cfg(not(target_os = "macos"))]
-        settings.insert("auto-optimise-store".to_string(), "true".to_string());
+            // https://github.com/DeterminateSystems/nix-installer/issues/449#issuecomment-1551782281
+            #[cfg(not(target_os = "macos"))]
+            settings.insert("auto-optimise-store".to_string(), "true".to_string());
 
-        settings.insert(
-            "bash-prompt-prefix".to_string(),
-            "(nix:$name)\\040".to_string(),
-        );
-        if let Some(ssl_cert_file) = ssl_cert_file {
-            let ssl_cert_file_canonical = ssl_cert_file
-                .canonicalize()
-                .map_err(|e| Self::error(ActionErrorKind::Canonicalize(ssl_cert_file, e)))?;
             settings.insert(
-                "ssl-cert-file".to_string(),
-                ssl_cert_file_canonical.display().to_string(),
+                "bash-prompt-prefix".to_string(),
+                "(nix:$name)\\040".to_string(),
             );
-        }
-        settings.insert(
-            "extra-nix-path".to_string(),
-            "nixpkgs=flake:nixpkgs".to_string(),
-        );
+            if let Some(ssl_cert_file) = ssl_cert_file {
+                let ssl_cert_file_canonical = ssl_cert_file
+                    .canonicalize()
+                    .map_err(|e| Self::error(ActionErrorKind::Canonicalize(ssl_cert_file, e)))?;
+                settings.insert(
+                    "ssl-cert-file".to_string(),
+                    ssl_cert_file_canonical.display().to_string(),
+                );
+            }
+            settings.insert(
+                "extra-nix-path".to_string(),
+                "nixpkgs=flake:nixpkgs".to_string(),
+            );
 
-        // Auto-allocate uids is broken on Mac. Tools like `whoami` don't work.
-        // e.g. https://github.com/NixOS/nix/issues/8444
-        #[cfg(not(target_os = "macos"))]
-        settings.insert("auto-allocate-uids".to_string(), "true".to_string());
+            // Auto-allocate uids is broken on Mac. Tools like `whoami` don't work.
+            // e.g. https://github.com/NixOS/nix/issues/8444
+            #[cfg(not(target_os = "macos"))]
+            settings.insert("auto-allocate-uids".to_string(), "true".to_string());
+        }
 
         let create_directory = CreateDirectory::plan(NIX_CONF_FOLDER, None, None, 0o0755, force)
             .await

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -36,7 +36,9 @@ impl PlaceNixConfiguration {
 
         settings.insert("build-users-group".to_string(), nix_build_group_name);
 
-        #[cfg(not(feature = "nix-community"))] {
+        #[cfg(not(feature = "nix-community"))]
+        {
+            use std::collections::hash_map::Entry;
             let experimental_features = ["nix-command", "flakes", "auto-allocate-uids"];
             match settings.entry("experimental-features".to_string()) {
                 Entry::Occupied(mut slot) => {

--- a/src/action/common/place_nix_configuration.rs
+++ b/src/action/common/place_nix_configuration.rs
@@ -39,6 +39,7 @@ impl PlaceNixConfiguration {
         #[cfg(not(feature = "nix-community"))]
         {
             use std::collections::hash_map::Entry;
+
             let experimental_features = ["nix-command", "flakes", "auto-allocate-uids"];
             match settings.entry("experimental-features".to_string()) {
                 Entry::Occupied(mut slot) => {

--- a/src/self_test.rs
+++ b/src/self_test.rs
@@ -107,7 +107,7 @@ impl Shell {
             .as_millis();
 
         command.arg(format!(
-            r#"nix build --no-link --expr 'derivation {{ name = "self-test-{executable}-{timestamp_millis}"; system = "{SYSTEM}"; builder = "/bin/sh"; args = ["-c" "echo hello > \$out"]; }}'"#
+            r#"nix-build --no-link --expr 'derivation {{ name = "self-test-{executable}-{timestamp_millis}"; system = "{SYSTEM}"; builder = "/bin/sh"; args = ["-c" "echo hello > \$out"]; }}'"#
         ));
         let command_str = format!("{:?}", command.as_std());
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -111,10 +111,6 @@ pub struct CommonSettings {
 
     /// Number of build users to create
     #[cfg_attr(
-        all(target_os = "linux", feature = "cli"),
-        doc = "On Linux, Nix's `auto-allocate-uids` feature will be enabled, so users don't need to be created."
-    )]
-    #[cfg_attr(
         feature = "cli",
         clap(
             long,
@@ -124,7 +120,7 @@ pub struct CommonSettings {
         )
     )]
     #[cfg_attr(all(target_os = "macos", feature = "cli"), clap(default_value = "32"))]
-    #[cfg_attr(all(target_os = "linux", feature = "cli"), clap(default_value = "0"))]
+    #[cfg_attr(all(target_os = "linux", feature = "cli"), clap(default_value = "32"))]
     pub nix_build_user_count: u32,
 
     /// The Nix build user base UID (ascending)
@@ -249,21 +245,21 @@ impl CommonSettings {
                 url = NIX_X64_64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
-                nix_build_user_count = 0;
+                nix_build_user_count = 32;
             },
             #[cfg(target_os = "linux")]
             (Architecture::X86_32(_), OperatingSystem::Linux) => {
                 url = NIX_I686_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
-                nix_build_user_count = 0;
+                nix_build_user_count = 32;
             },
             #[cfg(target_os = "linux")]
             (Architecture::Aarch64(_), OperatingSystem::Linux) => {
                 url = NIX_AARCH64_LINUX_URL;
                 nix_build_user_prefix = "nixbld";
                 nix_build_user_id_base = 30000;
-                nix_build_user_count = 0;
+                nix_build_user_count = 32;
             },
             #[cfg(target_os = "macos")]
             (Architecture::X86_64, OperatingSystem::MacOSX { .. })


### PR DESCRIPTION
Add a nix-community feature that disables experimental settings in
nix.conf

I'm sure there are some other approaches that could make this work (pass these settings to PlaceNixConfiguration::plan, or add a separate planner). But this seemed like the simplest and most straightforward

@abathur @hoverbear