### PR TITLE
Add working non-buildkite CI

### DIFF
--- a/.github/workflows/kiteless.yml
+++ b/.github/workflows/kiteless.yml
@@ -1,0 +1,505 @@
+name: kiteless CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lints:
+    name: Lints
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache lint store (x86_64-linux)
+        id: lint-store-x86_64-linux
+        uses: actions/cache@v3
+        with:
+          path: ~/.ci-store
+          key: lint-store-x86_64-linux-${{ hashFiles('**/Cargo.lock', '**/flake.lock') }}-v1
+      - name: Check rustfmt
+        run: nix develop --store ~/.ci-store --command check-rustfmt
+      - name: Check Spelling
+        run: nix develop --store ~/.ci-store --command check-spelling
+      - name: Check nixpkgs-fmt formatting
+        run: nix develop --store ~/.ci-store --command check-nixpkgs-fmt
+      - name: Check EditorConfig conformance
+        run: nix develop --store ~/.ci-store --command check-editorconfig
+
+  build-x86_64-linux:
+    name: Build x86_64 Linux
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache build store (x86_64-linux)
+        id: build-store-x86_64-linux
+        uses: actions/cache@v3
+        with:
+          path: ~/.ci-store
+          key: build-store-x86_64-linux-${{ hashFiles('**/Cargo.lock', '**/flake.lock') }}-v1
+      - name: Build `nix-installer-static`
+        run: nix build --store ~/.ci-store --print-build-logs .#packages.x86_64-linux.nix-installer-static
+      - name: Copy artifact
+        run: |
+          RESULT=$(nix eval --raw --store ~/.ci-store --print-build-logs .#packages.x86_64-linux.nix-installer-static --apply "x: \"$HOME/.ci-store\${x}\"")
+          cp $RESULT/bin/nix-installer nix-installer
+      - name: Create artifact for x86_64-linux nix-installer
+        uses: actions/upload-artifact@v3
+        with:
+          name: nix-installer-x86_64-linux
+          path: |
+            nix-installer
+
+  # Various feature variations or versions of the build which we expect to always work
+  # Since it uses the `build-store-x86_64-linux-*` cache it should be quite fast
+  build-variants-x86_64-linux:
+    name: Build x86_64 Linux (Variants)
+    runs-on: ubuntu-22.04
+    needs: build-x86_64-linux # Only run this if the normal checks work, to avoid clogging builders
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Cache build store (x86_64-linux)
+        id: build-store-x86_64-linux
+        uses: actions/cache@v3
+        with:
+          path: ~/.ci-store
+          key: build-store-x86_64-linux-${{ hashFiles('**/Cargo.lock', '**/flake.lock') }}-v1
+      - name: Build `nix-installer`
+        run: nix build --store ~/.ci-store --print-build-logs .#packages.x86_64-linux.nix-installer
+      - name: Test `nix develop` build without default features
+        run: nix develop --store ~/.ci-store --print-build-logs .# --command "cargo" build --no-default-features
+      - name: Test `nix develop` build all features
+        run: nix develop --store ~/.ci-store --print-build-logs .# --command "cargo" build --all-features
+
+  run-x86_64-linux:
+    name: Run x86_64 Linux
+    runs-on: ubuntu-22.04
+    needs: [build-x86_64-linux, lints]
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt install fish zsh
+      - uses: actions/download-artifact@v3
+        with:
+          name: nix-installer-x86_64-linux
+      - name: Move & set executable
+        run: |
+          chmod +x ./nix-installer
+          mkdir install-root
+          cp nix-installer.sh install-root/nix-installer.sh
+          mv nix-installer install-root/nix-installer-x86_64-linux
+      - name: Initial install
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=trace
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Initial uninstall (without a `nix run` first)
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run: |
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
+      - name: Repeated install
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=trace
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: echo $PATH
+        run: echo $PATH
+      - name: Test `nix` with `$GITHUB_PATH`
+        if: success() || failure()
+        run: |
+          nix run nixpkgs#fortune
+          nix profile install nixpkgs#fortune
+          fortune
+          nix store gc
+          nix run nixpkgs#fortune
+      - name: Test bash
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: bash --login {0}
+      - name: Test sh
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: sh -l {0}
+      - name: Test zsh
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: zsh --login --interactive {0}
+      - name: Test fish
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: fish --login {0}
+      - name: Repeated uninstall
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run: |
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
+
+  run-x86_64-linux-no-init:
+    name: Run x86_64 Linux (No init)
+    runs-on: ubuntu-22.04
+    needs: [build-x86_64-linux, lints]
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt install fish zsh
+      - uses: actions/download-artifact@v3
+        with:
+          name: nix-installer-x86_64-linux
+      - name: Move & set executable
+        run: |
+          chmod +x ./nix-installer
+          mkdir install-root
+          cp nix-installer.sh install-root/nix-installer.sh
+          mv nix-installer install-root/nix-installer-x86_64-linux
+      - name: Initial install
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          init: none
+          planner: linux
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=trace
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Ensure daemon was not configured with init
+        run: |
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was running"
+            exit 1
+          fi
+      - name: Initial uninstall (without a `nix run` first)
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run: |
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
+      - name: Repeated install
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          init: none
+          planner: linux
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=trace
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: echo $PATH
+        run: echo $PATH
+      - name: Test `nix` with `$GITHUB_PATH`
+        if: success() || failure()
+        run: |
+          sudo -i nix run nixpkgs#fortune
+          sudo -i nix profile install nixpkgs#fortune
+          fortune
+          sudo -i nix store gc
+          sudo -i nix run nixpkgs#fortune
+      - name: Test bash
+        run: sudo -i nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: bash --login {0}
+      - name: Test sh
+        run: sudo -i nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: sh -l {0}
+      - name: Test zsh
+        run: sudo -i nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: zsh --login --interactive {0}
+      - name: Test fish
+        run: sudo -i nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: fish --login {0}
+      - name: Repeated uninstall
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run: |
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
+
+  run-steam-deck:
+    name: Run Steam Deck (mock)
+    runs-on: ubuntu-22.04
+    needs: [build-x86_64-linux, lints]
+    steps:
+      - uses: actions/checkout@v3
+      - run: sudo apt install fish zsh
+      - uses: actions/download-artifact@v3
+        with:
+          name: nix-installer-x86_64-linux
+      - name: Move & set executable
+        run: |
+          chmod +x ./nix-installer
+          mkdir install-root
+          cp nix-installer.sh install-root/nix-installer.sh
+          mv nix-installer install-root/nix-installer-x86_64-linux
+      - name: Make the CI look like a steam deck
+        run: |
+          mkdir -p ~/bin
+          echo -e "#! /bin/sh\nexit 0" | sudo tee -a /bin/steamos-readonly
+          sudo chmod +x /bin/steamos-readonly
+          sudo useradd -m deck
+      - name: Initial install
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=trace
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          planner: steam-deck
+          extra-args: --persistence /home/runner/.ci-test-nix-home
+      - name: Initial uninstall (without a `nix run` first)
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run: |
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
+          if [ -e /home/runner/.ci-test-nix-home ]; then
+            echo "/home/runner/.ci-test-nix-home exists"
+            exit 1
+          fi
+      - name: Repeated install
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=trace
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          planner: steam-deck
+          extra-args: --persistence /home/runner/.ci-test-nix-home
+      - name: echo $PATH
+        run: echo $PATH
+      - name: Test `nix` with `$GITHUB_PATH`
+        if: success() || failure()
+        run: |
+          nix run nixpkgs#fortune
+          nix profile install nixpkgs#fortune
+          fortune
+          nix store gc
+          nix run nixpkgs#fortune
+      - name: Test bash
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: bash --login {0}
+      - name: Test sh
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: sh -l {0}
+      - name: Test zsh
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: zsh --login --interactive {0}
+      - name: Test fish
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: fish --login {0}
+      - name: Repeated uninstall
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          RUST_BACKTRACE: full
+      - name: Ensure `nix` is removed
+        run: |
+          if systemctl is-active nix-daemon.socket; then
+            echo "nix-daemon.socket was still running"
+            exit 1
+          fi
+          if systemctl is-active nix-daemon.service; then
+            echo "nix-daemon.service was still running"
+            exit 1
+          fi
+          if [ -e /nix ]; then
+            echo "/nix exists"
+            exit 1
+          fi
+          if [ -e /home/runner/.ci-test-nix-home ]; then
+            echo "/home/runner/.ci-test-nix-home exists"
+            exit 1
+          fi
+
+  build-x86_64-darwin:
+    name: Build x86_64 Darwin
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # Runs clippy as part of the preBuild.
+      - name: Build nix-installer
+        run: nix build .#packages.x86_64-darwin.nix-installer -L
+      - name: Create artifact for x86_64-darwin nix-installer
+        uses: actions/upload-artifact@v3
+        with:
+          name: nix-installer-x86_64-darwin
+          path: |
+            result/bin/nix-installer
+
+  run-x86_64-darwin:
+    name: Run x86_64 Darwin
+    runs-on: macos-12
+    needs: [build-x86_64-darwin, lints]
+    steps:
+      - uses: actions/checkout@v3
+      - run: brew install fish coreutils
+      - uses: actions/download-artifact@v3
+        with:
+          name: nix-installer-x86_64-darwin
+      - name: Move & set executable
+        run: |
+          chmod +x ./nix-installer
+          mkdir install-root
+          cp nix-installer.sh install-root/nix-installer.sh
+          mv nix-installer install-root/nix-installer-x86_64-darwin
+      - name: Initial install
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=trace
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf: |
+            trusted-users = root runner
+      - name: Initial uninstall (without a `nix run` first)
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          RUST_BACKTRACE: full
+      - name: Repeated install
+        uses: DeterminateSystems/nix-installer-action@v4
+        with:
+          local-root: install-root/
+          logger: pretty
+          log-directives: nix_installer=trace
+          backtrace: full
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-conf: trusted-users = root runner
+      - name: echo $PATH
+        run: echo $PATH
+      - name: Test `nix` with `$GITHUB_PATH`
+        if: success() || failure()
+        run: |
+          nix run nixpkgs#fortune
+          nix profile install nixpkgs#fortune
+          fortune
+          nix store gc
+          nix run nixpkgs#fortune
+      - name: Test bash
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: bash --login {0}
+      - name: Test sh
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: sh -l {0}
+      - name: Test zsh
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: zsh --login --interactive {0}
+      - name: Test fish
+        run: nix-instantiate -E 'builtins.currentTime' --eval
+        if: success() || failure()
+        shell: fish --login {0}
+      - name: Repeated uninstall
+        run: sudo -E /nix/nix-installer uninstall
+        env:
+          NIX_INSTALLER_NO_CONFIRM: true
+          NIX_INSTALLER_LOGGER: pretty
+          NIX_INSTALLER_LOG_DIRECTIVES: nix_installer=trace
+          RUST_BACKTRACE: full

--- a/flake.nix
+++ b/flake.nix
@@ -206,15 +206,15 @@
 
       hydraJobs = {
         build = forAllSystems ({ system, pkgs, ... }: self.packages.${system}.default);
-        vm-test = import ./nix/tests/vm-test {
-          inherit forSystem;
-          inherit (nix.hydraJobs) binaryTarball;
-          inherit (nixpkgs) lib;
-        };
-        container-test = import ./nix/tests/container-test {
-          inherit forSystem;
-          inherit (nix.hydraJobs) binaryTarball;
-        };
+        # vm-test = import ./nix/tests/vm-test {
+        #   inherit forSystem;
+        #   inherit (nix.hydraJobs) binaryTarball;
+        #   inherit (nixpkgs) lib;
+        # };
+        # container-test = import ./nix/tests/container-test {
+        #   inherit forSystem;
+        #   inherit (nix.hydraJobs) binaryTarball;
+        # };
       };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -205,6 +205,7 @@
         });
 
       hydraJobs = {
+        build = forAllSystems ({ system, pkgs, ... }: self.packages.${system}.default);
         vm-test = import ./nix/tests/vm-test {
           inherit forSystem;
           inherit (nix.hydraJobs) binaryTarball;


### PR DESCRIPTION
Adding a new GA workflow based on the upstream's old pre-buildkite CI back at version 0.2.0. Needed to fix up planners for change since then. Separate workflow to minimize ongoing conflicts.

Also disables most of the tests in the hydra jobs for speed. We may want to selectively re-enable later once we're on our feet.