### PR TITLE
try hello instead of fortune

### DIFF
--- a/.github/workflows/kiteless.yml
+++ b/.github/workflows/kiteless.yml
@@ -140,11 +140,11 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          nix run nixpkgs#fortune
-          nix profile install nixpkgs#fortune
-          fortune
+          nix run nixpkgs#hello
+          nix profile install nixpkgs#hello
+          hello
           nix store gc
-          nix run nixpkgs#fortune
+          nix run nixpkgs#hello
       - name: Test bash
         run: nix-instantiate -E 'builtins.currentTime' --eval
         if: success() || failure()
@@ -247,11 +247,11 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          sudo -i nix run nixpkgs#fortune
-          sudo -i nix profile install nixpkgs#fortune
-          fortune
+          sudo -i nix run nixpkgs#hello
+          sudo -i nix profile install nixpkgs#hello
+          hello
           sudo -i nix store gc
-          sudo -i nix run nixpkgs#fortune
+          sudo -i nix run nixpkgs#hello
       - name: Test bash
         run: sudo -i nix-instantiate -E 'builtins.currentTime' --eval
         if: success() || failure()
@@ -362,11 +362,11 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          nix run nixpkgs#fortune
-          nix profile install nixpkgs#fortune
-          fortune
+          nix run nixpkgs#hello
+          nix profile install nixpkgs#hello
+          hello
           nix store gc
-          nix run nixpkgs#fortune
+          nix run nixpkgs#hello
       - name: Test bash
         run: nix-instantiate -E 'builtins.currentTime' --eval
         if: success() || failure()
@@ -475,11 +475,11 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          nix run nixpkgs#fortune
-          nix profile install nixpkgs#fortune
-          fortune
+          nix run nixpkgs#hello
+          nix profile install nixpkgs#hello
+          hello
           nix store gc
-          nix run nixpkgs#fortune
+          nix run nixpkgs#hello
       - name: Test bash
         run: nix-instantiate -E 'builtins.currentTime' --eval
         if: success() || failure()


### PR DESCRIPTION
CI has been using `fortune` package/CLI as a trivial test, but it looks like the macOS test was disabled upstream for flakiness after the commit I pulled this in from, and we've encountered flakiness here.

I've run the macOS job for this branch (which uses `hello` instead of `fortune` 10x and haven't seen a failure. Maybe that's enough?