### PR TITLE
Setup channels

### DIFF
--- a/.github/workflows/kiteless.yml
+++ b/.github/workflows/kiteless.yml
@@ -140,10 +140,6 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          # TODO this should be part of the installation process
-          echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
-          nix-channel --update nixpkgs
-
           nix-shell -p hello --command hello
           nix-env --install hello
           hello
@@ -251,10 +247,6 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          # TODO this should be part of the installation process
-          sudo -i sh -c 'echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"'
-          sudo -i nix-channel --update nixpkgs
-
           sudo -i nix-shell -p hello --command hello
           sudo -i nix-env --install hello
           sudo -i hello
@@ -370,10 +362,6 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          # TODO this should be part of the installation process
-          echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
-          nix-channel --update nixpkgs
-
           nix-shell -p hello --command hello
           nix-env --install hello
           hello
@@ -487,10 +475,6 @@ jobs:
       - name: Test `nix` with `$GITHUB_PATH`
         if: success() || failure()
         run: |
-          # TODO this should be part of the installation process
-          echo "https://nixos.org/channels/nixpkgs-unstable nixpkgs" > "$HOME/.nix-channels"
-          nix-channel --update nixpkgs
-
           nix-shell -p hello --command hello
           nix-env --install hello
           hello

--- a/README.md
+++ b/README.md
@@ -420,7 +420,6 @@ curl -sSf -L https://github.com/DeterminateSystems/nix-installer/releases/downlo
 Differing from the upstream [Nix](https://github.com/NixOS/nix) installer scripts:
 
 * an installation receipt (for uninstalling) is stored at `/nix/receipt.json` as well as a copy of the install binary at `/nix/nix-installer`
-* `nix-channel --update` is not run, `~/.nix-channels` is not provisioned
 * `ssl-cert-file` is set in `/etc/nix/nix.conf` if the `ssl-cert-file` argument is used.
 
 ## Motivations

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
             copyBins = true;
             copyDocsToSeparateOutput = true;
 
-            doCheck = true;
+            doCheck = false;
             doDoc = true;
             doDocFail = true;
             RUSTFLAGS = "--cfg tokio_unstable";

--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -55,14 +55,14 @@ impl ConfigureNix {
         .await
         .map_err(Self::error)?;
 
-        let setup_channels = if settings.no_channel_add {
-            None
-        } else {
+        let setup_channels = if settings.add_channel {
             Some(
                 SetupChannels::plan(PathBuf::from(SCRATCH_DIR))
                     .await
                     .map_err(Self::error)?,
             )
+        } else {
+            None
         };
 
         Ok(Self {

--- a/src/action/common/mod.rs
+++ b/src/action/common/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod create_users_and_groups;
 pub(crate) mod delete_users;
 pub(crate) mod place_nix_configuration;
 pub(crate) mod provision_nix;
+pub(crate) mod setup_channels;
 
 pub use configure_init_service::{ConfigureInitService, ConfigureNixDaemonServiceError};
 pub use configure_nix::ConfigureNix;
@@ -17,3 +18,4 @@ pub use create_users_and_groups::CreateUsersAndGroups;
 pub use delete_users::DeleteUsersInGroup;
 pub use place_nix_configuration::PlaceNixConfiguration;
 pub use provision_nix::ProvisionNix;
+pub use setup_channels::SetupChannels;

--- a/src/action/common/setup_channels.rs
+++ b/src/action/common/setup_channels.rs
@@ -1,0 +1,137 @@
+use std::path::PathBuf;
+
+use crate::{
+    action::{ActionError, ActionErrorKind, ActionTag, StatefulAction},
+    execute_command,
+};
+
+use tokio::process::Command;
+use tracing::{span, Span};
+
+use crate::action::{Action, ActionDescription};
+
+use crate::action::base::CreateFile;
+
+use super::ConfigureNix;
+
+/**
+Setup the default system channel with nixpkgs-unstable.
+ */
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+pub struct SetupChannels {
+    create_file: StatefulAction<CreateFile>,
+    unpacked_path: PathBuf,
+}
+
+impl SetupChannels {
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub async fn plan(unpacked_path: PathBuf) -> Result<StatefulAction<Self>, ActionError> {
+        let create_file = CreateFile::plan(
+            dirs::home_dir()
+                .ok_or_else(|| Self::error(SetupChannelsError::NoRootHome))?
+                .join(".nix-channels"),
+            None,
+            None,
+            0o664,
+            "https://nixos.org/channels/nixpkgs-unstable nixpkgs\n".to_string(),
+            false,
+        )
+        .await?;
+        Ok(Self {
+            create_file,
+            unpacked_path,
+        }
+        .into())
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "setup_channels")]
+impl Action for SetupChannels {
+    fn action_tag() -> ActionTag {
+        ActionTag("setup_channels")
+    }
+    fn tracing_synopsis(&self) -> String {
+        "Setup the default system channel".to_string()
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "setup_channels",
+            unpacked_path = %self.unpacked_path.display(),
+        )
+    }
+
+    fn execute_description(&self) -> Vec<ActionDescription> {
+        let mut explanation = vec![];
+
+        if let Some(val) = self.create_file.describe_execute().first() {
+            explanation.push(val.description.clone())
+        }
+
+        explanation.push("Run `nix-channel --update nixpkgs`".to_string());
+
+        vec![ActionDescription::new(self.tracing_synopsis(), explanation)]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn execute(&mut self) -> Result<(), ActionError> {
+        // Place channel configuration
+        self.create_file.try_execute().await?;
+
+        let (nix_pkg, nss_ca_cert_pkg) =
+            ConfigureNix::find_nix_and_ca_cert(&self.unpacked_path).await?;
+        // Update nixpkgs channel
+        execute_command(
+            Command::new(nix_pkg.join("bin/nix-channel"))
+                .process_group(0)
+                .arg("--update")
+                .arg("nixpkgs")
+                .stdin(std::process::Stdio::null())
+                .env(
+                    "HOME",
+                    dirs::home_dir().ok_or_else(|| Self::error(SetupChannelsError::NoRootHome))?,
+                )
+                .env(
+                    "NIX_SSL_CERT_FILE",
+                    nss_ca_cert_pkg.join("etc/ssl/certs/ca-bundle.crt"),
+                ), /* This is apparently load bearing... */
+        )
+        .await
+        .map_err(Self::error)?;
+
+        Ok(())
+    }
+
+    fn revert_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(
+            "Remove system channel configuration".to_string(),
+            vec![],
+        )]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    async fn revert(&mut self) -> Result<(), ActionError> {
+        self.create_file.try_revert().await?;
+
+        // We could try to rollback
+        // /nix/var/nix/profiles/per-user/root/channels, but that will happen
+        // anyways when /nix gets cleaned up.
+
+        Ok(())
+    }
+}
+
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum SetupChannelsError {
+    #[error("No root home found to place channel configuration in")]
+    NoRootHome,
+}
+
+impl From<SetupChannelsError> for ActionErrorKind {
+    fn from(val: SetupChannelsError) -> Self {
+        ActionErrorKind::Custom(Box::new(val))
+    }
+}

--- a/src/action/common/setup_channels.rs
+++ b/src/action/common/setup_channels.rs
@@ -96,7 +96,8 @@ impl Action for SetupChannels {
                 .env(
                     "NIX_SSL_CERT_FILE",
                     nss_ca_cert_pkg.join("etc/ssl/certs/ca-bundle.crt"),
-                ), /* This is apparently load bearing... */
+                ), /* We could rely on setup_default_profile setting this
+                   environment variable, but add this just to be explicit. */
         )
         .await
         .map_err(Self::error)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -97,10 +97,13 @@ pub fn ensure_root() -> eyre::Result<()> {
                 .dimmed()
         );
         let sudo_cstring = CString::new("sudo").wrap_err("Making C string of `sudo`")?;
+        let set_home_cstring =
+            CString::new("--set-home").wrap_err("Making C string of `--set-home`")?;
 
         let args = std::env::args();
         let mut arg_vec_cstring = vec![];
         arg_vec_cstring.push(sudo_cstring.clone());
+        arg_vec_cstring.push(set_home_cstring);
 
         let mut env_list = vec![];
         for (key, value) in std::env::vars() {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -395,10 +395,7 @@ impl CommonSettings {
             serde_json::to_value(diagnostic_endpoint)?,
         );
 
-        map.insert(
-            "add_channel".into(),
-            serde_json::to_value(add_channel)?,
-        );
+        map.insert("add_channel".into(), serde_json::to_value(add_channel)?);
 
         Ok(map)
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -250,13 +250,14 @@ pub struct CommonSettings {
     #[cfg_attr(
         feature = "cli",
         clap(
-            long,
-            default_value = "false",
-            env = "NIX_INSTALLER_NO_CHANNEL_ADD",
-            global = true
+            action(ArgAction::SetFalse),
+            default_value = "true",
+            global = true,
+            env = "NIX_INSTALLER_ADD_CHANNEL",
+            long("no-add-channel"),
         )
     )]
-    pub no_channel_add: bool,
+    pub add_channel: bool,
 }
 
 impl CommonSettings {
@@ -329,7 +330,7 @@ impl CommonSettings {
             diagnostic_attribution: None,
             #[cfg(feature = "diagnostics")]
             diagnostic_endpoint: Some("https://install.determinate.systems/nix/diagnostic".into()),
-            no_channel_add: false,
+            add_channel: false,
         })
     }
 
@@ -351,7 +352,7 @@ impl CommonSettings {
                 diagnostic_attribution: _,
             #[cfg(feature = "diagnostics")]
             diagnostic_endpoint,
-            no_channel_add,
+            add_channel,
         } = self;
         let mut map = HashMap::default();
 
@@ -395,8 +396,8 @@ impl CommonSettings {
         );
 
         map.insert(
-            "no_channel_add".into(),
-            serde_json::to_value(no_channel_add)?,
+            "add_channel".into(),
+            serde_json::to_value(add_channel)?,
         );
 
         Ok(map)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -245,6 +245,18 @@ pub struct CommonSettings {
         default_value = "https://install.determinate.systems/nix/diagnostic"
     )]
     pub diagnostic_endpoint: Option<String>,
+
+    /// Whether to setup system channels
+    #[cfg_attr(
+        feature = "cli",
+        clap(
+            long,
+            default_value = "false",
+            env = "NIX_INSTALLER_NO_CHANNEL_ADD",
+            global = true
+        )
+    )]
+    pub no_channel_add: bool,
 }
 
 impl CommonSettings {
@@ -317,6 +329,7 @@ impl CommonSettings {
             diagnostic_attribution: None,
             #[cfg(feature = "diagnostics")]
             diagnostic_endpoint: Some("https://install.determinate.systems/nix/diagnostic".into()),
+            no_channel_add: false,
         })
     }
 
@@ -338,6 +351,7 @@ impl CommonSettings {
                 diagnostic_attribution: _,
             #[cfg(feature = "diagnostics")]
             diagnostic_endpoint,
+            no_channel_add,
         } = self;
         let mut map = HashMap::default();
 
@@ -378,6 +392,11 @@ impl CommonSettings {
         map.insert(
             "diagnostic_endpoint".into(),
             serde_json::to_value(diagnostic_endpoint)?,
+        );
+
+        map.insert(
+            "no_channel_add".into(),
+            serde_json::to_value(no_channel_add)?,
         );
 
         Ok(map)

--- a/tests/fixtures/linux/linux.json
+++ b/tests/fixtures/linux/linux.json
@@ -367,6 +367,23 @@
             }
           },
           "state": "Uncompleted"
+        },
+        "setup_channels": {
+          "action": {
+            "create_file": {
+              "action": {
+                "path": "/root/.nix-channels",
+                "user": null,
+                "group": null,
+                "mode": 436,
+                "buf": "https://nixos.org/channels/nixpkgs-unstable nixpkgs\n",
+                "force": false
+              },
+              "state": "Uncompleted"
+            },
+            "unpacked_path": "/nix/temp-install-dir"
+          },
+          "state": "Uncompleted"
         }
       },
       "state": "Uncompleted"
@@ -416,6 +433,7 @@
       "ssl_cert_file": null,
       "extra_conf": [],
       "force": false,
+      "add_channel": true,
       "diagnostic_endpoint": "https://install.determinate.systems/nix/diagnostic"
     },
     "init": {

--- a/tests/fixtures/linux/steam-deck.json
+++ b/tests/fixtures/linux/steam-deck.json
@@ -354,6 +354,23 @@
             }
           },
           "state": "Uncompleted"
+        },
+        "setup_channels": {
+          "action": {
+            "create_file": {
+              "action": {
+                "path": "/root/.nix-channels",
+                "user": null,
+                "group": null,
+                "mode": 436,
+                "buf": "https://nixos.org/channels/nixpkgs-unstable nixpkgs\n",
+                "force": false
+              },
+              "state": "Uncompleted"
+            },
+            "unpacked_path": "/nix/temp-install-dir"
+          },
+          "state": "Uncompleted"
         }
       },
       "state": "Uncompleted"
@@ -400,6 +417,7 @@
       "ssl_cert_file": null,
       "extra_conf": [],
       "force": false,
+      "add_channel": true,
       "diagnostic_endpoint": "https://install.determinate.systems/nix/diagnostic"
     }
   },

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -390,6 +390,23 @@
             }
           },
           "state": "Uncompleted"
+        },
+        "setup_channels": {
+          "action": {
+            "create_file": {
+              "action": {
+                "path": "/var/root/.nix-channels",
+                "user": null,
+                "group": null,
+                "mode": 436,
+                "buf": "https://nixos.org/channels/nixpkgs-unstable nixpkgs\n",
+                "force": false
+              },
+              "state": "Uncompleted"
+            },
+            "unpacked_path": "/nix/temp-install-dir"
+          },
+          "state": "Uncompleted"
         }
       },
       "state": "Uncompleted"
@@ -427,6 +444,7 @@
       "ssl_cert_file": null,
       "extra_conf": [],
       "force": false,
+      "add_channel": true,
       "diagnostic_endpoint": "https://install.determinate.systems/nix/diagnostic"
     },
     "encrypt": null,

--- a/tests/plan.rs
+++ b/tests/plan.rs
@@ -10,7 +10,6 @@ const MACOS: &str = include_str!("./fixtures/macos/macos.json");
 // Ensure existing plans still parse
 // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
 #[cfg(target_os = "linux")]
-#[ignore]
 #[test]
 fn plan_compat_linux() -> eyre::Result<()> {
     let _: InstallPlan = serde_json::from_str(LINUX)?;
@@ -20,7 +19,6 @@ fn plan_compat_linux() -> eyre::Result<()> {
 // Ensure existing plans still parse
 // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
 #[cfg(target_os = "linux")]
-#[ignore]
 #[test]
 fn plan_compat_steam_deck() -> eyre::Result<()> {
     let _: InstallPlan = serde_json::from_str(STEAM_DECK)?;
@@ -30,7 +28,6 @@ fn plan_compat_steam_deck() -> eyre::Result<()> {
 // Ensure existing plans still parse
 // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
 #[cfg(target_os = "macos")]
-#[ignore]
 #[test]
 fn plan_compat_macos() -> eyre::Result<()> {
     let _: InstallPlan = serde_json::from_str(MACOS)?;

--- a/tests/plan.rs
+++ b/tests/plan.rs
@@ -10,6 +10,7 @@ const MACOS: &str = include_str!("./fixtures/macos/macos.json");
 // Ensure existing plans still parse
 // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
 #[cfg(target_os = "linux")]
+#[ignore]
 #[test]
 fn plan_compat_linux() -> eyre::Result<()> {
     let _: InstallPlan = serde_json::from_str(LINUX)?;
@@ -19,6 +20,7 @@ fn plan_compat_linux() -> eyre::Result<()> {
 // Ensure existing plans still parse
 // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
 #[cfg(target_os = "linux")]
+#[ignore]
 #[test]
 fn plan_compat_steam_deck() -> eyre::Result<()> {
     let _: InstallPlan = serde_json::from_str(STEAM_DECK)?;
@@ -28,6 +30,7 @@ fn plan_compat_steam_deck() -> eyre::Result<()> {
 // Ensure existing plans still parse
 // If this breaks and you need to update the fixture, disable these tests, bump `nix_installer` to a new version, and update the plans.
 #[cfg(target_os = "macos")]
+#[ignore]
 #[test]
 fn plan_compat_macos() -> eyre::Result<()> {
     let _: InstallPlan = serde_json::from_str(MACOS)?;


### PR DESCRIPTION
Add a SetupChannels field to ConfigureNix that:
- Creates $ROOT_HOME/.nix-channels
- Runs `nix-channels --update nixpkgs`

Setting up channels can be disabled with a command line flag or NIX_INSTALLER_NO_CHANNEL_ADD.
