### PR TITLE
Fix git issue with prerelease job

### DIFF
--- a/.github/workflows/release-script.yml
+++ b/.github/workflows/release-script.yml
@@ -19,3 +19,6 @@ jobs:
         commit_message: "Update installer script"
         commit_user_name: "GitHub Actions"
         branch: prerelease
+        # assemble_installer.py already does a fetch and checkout
+        skip_fetch: true
+        skip_checkout: true

--- a/assemble_installer.py
+++ b/assemble_installer.py
@@ -24,5 +24,8 @@ for build_id in hydra_eval['builds']:
     else:
         sys.exit(0)
 
+subprocess.run(["git", "fetch", "origin", "prerelease"], check=True)
+subprocess.run(["git", "checkout", "-b", "prerelease", "origin/prerelease"], check=True)
+
 for installer_url, system in installers:
     shutil.copy(f"{installer_url}/bin/nix-installer", f"nix-installer-{system}")


### PR DESCRIPTION
Currently the prerelease job fails with:
```
error: The following untracked working tree files would be overwritten by checkout:
	nix-installer-aarch64-darwin
	nix-installer-aarch64-linux
	nix-installer-i686-linux
	nix-installer-x86_64-darwin
	nix-installer-x86_64-linux
```
https://github.com/NixOS/experimental-nix-installer/actions/runs/11708583897/job/32610685871

This is because assemble_installer.py adds those files on main, but then the job tries to checkout prerelease.

Instead, fetch and checkout the prerelease branch in assemble_installer.py before creating those files.