### PR TITLE
Update flake inputs & get CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
     needs: [lints, build-x86_64-linux]
     strategy:
       matrix:
-        determinate: [true, false]
+        determinate: [false]
     permissions:
       id-token: "write"
       contents: "read"
@@ -187,7 +187,7 @@ jobs:
     needs: [lints, build-x86_64-linux]
     strategy:
       matrix:
-        determinate: [true, false]
+        determinate: [false]
     permissions:
       id-token: "write"
       contents: "read"
@@ -311,7 +311,7 @@ jobs:
     needs: [lints, build-x86_64-darwin]
     strategy:
       matrix:
-        determinate: [true, false]
+        determinate: [false]
     permissions:
       id-token: "write"
       contents: "read"
@@ -402,7 +402,7 @@ jobs:
   #   needs: [lints, build-aarch64-linux]
   #   strategy:
   #     matrix:
-  #       determinate: [true, false]
+  #       determinate: [false]
   #   permissions:
   #     id-token: "write"
   #     contents: "read"
@@ -520,7 +520,7 @@ jobs:
     needs: [lints, build-aarch64-darwin]
     strategy:
       matrix:
-        determinate: [true, false]
+        determinate: [false]
     permissions:
       id-token: "write"
       contents: "read"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -572,14 +572,15 @@ jobs:
           logger: pretty
       - name: echo $PATH
         run: echo $PATH
-      - name: Test `nix` with `$GITHUB_PATH`
-        if: success() || failure()
-        run: |
-          nix run nixpkgs#hello
-          nix profile install nixpkgs#hello
-          hello
-          nix store gc
-          nix run nixpkgs#hello
+      # We don't enable flakes by default.
+      # - name: Test `nix` with `$GITHUB_PATH`
+      #   if: success() || failure()
+      #   run: |
+      #     nix run nixpkgs#hello
+      #     nix profile install nixpkgs#hello
+      #     hello
+      #     nix store gc
+      #     nix run nixpkgs#hello
       # NOTE(cole-h): GHA pushed a weird image that breaks this test for whatever reason, so ignore
       # the failure for now
       - name: Test bash

--- a/assemble_installer.py
+++ b/assemble_installer.py
@@ -1,6 +1,6 @@
 import requests
 import subprocess
-import shutil 
+import shutil
 import sys
 
 response = requests.get('https://hydra.nixos.org/jobset/experimental-nix-installer/experimental-installer/evals', headers={'Accept': 'application/json'})

--- a/flake.lock
+++ b/flake.lock
@@ -1,70 +1,5 @@
 {
   "nodes": {
-    "determinate": {
-      "inputs": {
-        "determinate-nixd-aarch64-darwin": "determinate-nixd-aarch64-darwin",
-        "determinate-nixd-aarch64-linux": "determinate-nixd-aarch64-linux",
-        "determinate-nixd-x86_64-darwin": [
-          "determinate",
-          "determinate-nixd-aarch64-darwin"
-        ],
-        "determinate-nixd-x86_64-linux": "determinate-nixd-x86_64-linux",
-        "nix": [
-          "nix"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1729548094,
-        "narHash": "sha256-+jP+Zlg0prpcmBy5s7cPUa7nJr90Zm2m933aibrHBYw=",
-        "rev": "5babe9d6a9eb52ee001bf70ad607fd66522f781b",
-        "revCount": 145,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/determinate/0.1.145%2Brev-5babe9d6a9eb52ee001bf70ad607fd66522f781b/0192b11b-c96e-7199-ba89-8c923541fcce/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/DeterminateSystems/determinate/0.1.tar.gz"
-      }
-    },
-    "determinate-nixd-aarch64-darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-OhG8joS/uN3Kdw4h9w8F/6ZIVTFZ8J9Fb4NGn/KK5/s=",
-        "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/51ecec5a3148baef87c2015536aa12dd18e4c4ad/macOS"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/51ecec5a3148baef87c2015536aa12dd18e4c4ad/macOS"
-      }
-    },
-    "determinate-nixd-aarch64-linux": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-AGcHQSIdb+KEJlhJzMB4YyFxbjdLZEDDf6bv6Zi3wqM=",
-        "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/51ecec5a3148baef87c2015536aa12dd18e4c4ad/aarch64-linux"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/51ecec5a3148baef87c2015536aa12dd18e4c4ad/aarch64-linux"
-      }
-    },
-    "determinate-nixd-x86_64-linux": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-kU4dqHoYe3sFf4LDAUj4fyl9uGV8IHtE22+DdMeRN0s=",
-        "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/51ecec5a3148baef87c2015536aa12dd18e4c4ad/x86_64-linux"
-      },
-      "original": {
-        "type": "file",
-        "url": "https://install.determinate.systems/determinate-nixd/rev/51ecec5a3148baef87c2015536aa12dd18e4c4ad/x86_64-linux"
-      }
-    },
     "fenix": {
       "inputs": {
         "nixpkgs": [
@@ -299,7 +234,6 @@
     },
     "root": {
       "inputs": {
-        "determinate": "determinate",
         "fenix": "fenix",
         "flake-compat": "flake-compat",
         "naersk": "naersk",

--- a/flake.lock
+++ b/flake.lock
@@ -8,17 +8,17 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1714544767,
-        "narHash": "sha256-kF1bX+YFMedf1g0PAJYwGUkzh22JmULtj8Rm4IXAQKs=",
+        "lastModified": 1727764514,
+        "narHash": "sha256-tvN9v5gTxLI5zOKsNvYl1aUxIitHm8Nj3vKdXNfJo50=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "73124e1356bde9411b163d636b39fe4804b7ca45",
+        "rev": "a9d2e5fa8d77af05240230c9569bbbddd28ccfaf",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "73124e1356bde9411b163d636b39fe4804b7ca45",
+        "rev": "a9d2e5fa8d77af05240230c9569bbbddd28ccfaf",
         "type": "github"
       }
     },
@@ -244,11 +244,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1714501997,
-        "narHash": "sha256-g31zfxwUFzkPgX0Q8sZLcrqGmOxwjEZ/iqJjNx4fEGo=",
+        "lastModified": 1727706011,
+        "narHash": "sha256-xxgUHwwJ+1xQQoUWvLDo807IZ0MDldkfr9N1G4fvNJU=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "49e502b277a8126a9ad10c802d1aaa3ef1a280ef",
+        "rev": "28830ff2f1158ee92f4852ef3ec35af0935d1562",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -130,11 +130,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721727458,
-        "narHash": "sha256-r/xppY958gmZ4oTfLiHN0ZGuQ+RSTijDblVgVLFi1mw=",
+        "lastModified": 1733346208,
+        "narHash": "sha256-a4WZp1xQkrnA4BbnKrzJNr+dYoQr5Xneh2syJoddFyE=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "3fb418eaf352498f6b6c30592e3beb63df42ef11",
+        "rev": "378614f37a6bee5a3f2ef4f825a73d948d3ae921",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -218,17 +218,17 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1714635257,
-        "narHash": "sha256-4cPymbty65RvF1DWQfc+Bc8B233A1BWxJnNULJKQ1EY=",
+        "lastModified": 1730200266,
+        "narHash": "sha256-l253w0XMT8nWHGXuXqyiIC/bMvh1VRszGXgdpQlfhvU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63c3a29ca82437c87573e4c6919b09a24ea61b0f",
+        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63c3a29ca82437c87573e4c6919b09a24ea61b0f",
+        "rev": "807e9154dcb16384b1b765ebe9cd2bba2ac287fd",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,8 @@
             nativeBuildInputs = with final; [ ];
             buildInputs = with final; [ ] ++ lib.optionals (final.stdenv.isDarwin) (with final.darwin.apple_sdk.frameworks; [
               SystemConfiguration
+              # temporary fix for naersk to nix flake update; see df13b0b upstream
+              final.darwin.libiconv
             ]);
 
             copyBins = true;

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Experimental Nix Installer";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/63c3a29ca82437c87573e4c6919b09a24ea61b0f";
+    nixpkgs.url = "github:NixOS/nixpkgs/807e9154dcb16384b1b765ebe9cd2bba2ac287fd";
 
     fenix = {
       url = "github:nix-community/fenix/73124e1356bde9411b163d636b39fe4804b7ca45";

--- a/flake.nix
+++ b/flake.nix
@@ -18,19 +18,19 @@
       url = "github:NixOS/nix/2.24.9";
       # Omitting `inputs.nixpkgs.follows = "nixpkgs";` on purpose
     };
+    # We don't use this, so let's save download/update time
+    # determinate = {
+    #   url = "https://flakehub.com/f/DeterminateSystems/determinate/0.1.tar.gz";
 
-    determinate = {
-      url = "https://flakehub.com/f/DeterminateSystems/determinate/0.1.tar.gz";
-
-      # We set the overrides below so the flake.lock has many fewer nodes.
-      #
-      # The `determinate` input is used to access the builds of `determinate-nixd`.
-      # Below, we access the `packages` outputs, which download static builds of `determinate-nixd` and makes them executable.
-      # The way we consume the determinate flake means the `nix` and `nixpkgs` inputs are not meaningfully used.
-      # This means `follows` won't cause surprisingly extensive rebuilds, just trivial `chmod +x` rebuilds.
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nix.follows = "nix";
-    };
+    #   # We set the overrides below so the flake.lock has many fewer nodes.
+    #   #
+    #   # The `determinate` input is used to access the builds of `determinate-nixd`.
+    #   # Below, we access the `packages` outputs, which download static builds of `determinate-nixd` and makes them executable.
+    #   # The way we consume the determinate flake means the `nix` and `nixpkgs` inputs are not meaningfully used.
+    #   # This means `follows` won't cause surprisingly extensive rebuilds, just trivial `chmod +x` rebuilds.
+    #   inputs.nixpkgs.follows = "nixpkgs";
+    #   inputs.nix.follows = "nix";
+    # };
 
     flake-compat.url = "github:edolstra/flake-compat/v1.0.0";
   };
@@ -41,7 +41,7 @@
     , fenix
     , naersk
     , nix
-    , determinate
+      # , determinate
     , ...
     } @ inputs:
     let

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
     } @ inputs:
     let
       supportedSystems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      systemsSupportedByDeterminateNixd = [  ]; # avoid refs to detsys nixd for now
+      systemsSupportedByDeterminateNixd = [ ]; # avoid refs to detsys nixd for now
 
       forAllSystems = f: nixpkgs.lib.genAttrs supportedSystems (system: (forSystem system f));
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,14 @@
   description = "Experimental Nix Installer";
 
   inputs = {
+    # can track upstream versioning with
+    # git show $most_recently_merged_commit:flake.lock | jq '.nodes[.nodes.root.inputs.nixpkgs].locked.rev'
     nixpkgs.url = "github:NixOS/nixpkgs/807e9154dcb16384b1b765ebe9cd2bba2ac287fd";
 
     fenix = {
-      url = "github:nix-community/fenix/73124e1356bde9411b163d636b39fe4804b7ca45";
+      # can track upstream versioning with
+      # git show $most_recently_merged_commit:flake.lock | jq '.nodes[.nodes.root.inputs.fenix].locked.rev'
+      url = "github:nix-community/fenix/a9d2e5fa8d77af05240230c9569bbbddd28ccfaf";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/src/planner/linux.rs
+++ b/src/planner/linux.rs
@@ -8,7 +8,7 @@ use crate::{
     action::{
         base::{CreateDirectory, RemoveDirectory},
         common::{
-            ConfigureNix, ConfigureDeterminateNixdInitService, ConfigureUpstreamInitService,
+            ConfigureDeterminateNixdInitService, ConfigureNix, ConfigureUpstreamInitService,
             CreateUsersAndGroups, ProvisionDeterminateNixd, ProvisionNix,
         },
         linux::{

--- a/src/planner/macos/mod.rs
+++ b/src/planner/macos/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     action::{
         base::RemoveDirectory,
         common::{
-            ConfigureNix, ConfigureDeterminateNixdInitService, ConfigureUpstreamInitService,
+            ConfigureDeterminateNixdInitService, ConfigureNix, ConfigureUpstreamInitService,
             CreateUsersAndGroups, ProvisionDeterminateNixd, ProvisionNix,
         },
         macos::{


### PR DESCRIPTION
@mkenigs We're mostly doing the same thing at the same time. IIRC my main differences with your draft are:

1. I'm using the nixpkgs rev Cole mentioned during the meeting this week instead of matching the equivalent rev from their 0.27.0 release.
2. I commented out the determinate input instead of deleting it.

I didn't initially have the fenix update, but I picked up that and your comments about commands for finding those revs as well.

CI will hopefully run green here since it already has on the branch: https://github.com/NixOS/experimental-nix-installer/actions/runs/12436022462/job/34723911830