### PR TITLE
Fix release script quoting

### DIFF
--- a/.github/workflows/release-script.yml
+++ b/.github/workflows/release-script.yml
@@ -17,6 +17,6 @@ jobs:
     - uses: cachix/install-nix-action@v25
     - name: Create draft release
       # The script also depends on gh and git but those are both pre-installed on the runner
-      run: nix-shell -p python3Packages.requests --run "python assemble_installer.py ${{ github.event.inputs.testing_hydra_eval_id }}" -I nixpkgs=channel:nixos-23.11
+      run: nix-shell -p python3Packages.requests --run 'python assemble_installer.py "${{ github.event.inputs.testing_hydra_eval_id }}"' -I nixpkgs=channel:nixos-23.11
       env:
         GH_TOKEN: ${{ github.token }}

--- a/assemble_installer.py
+++ b/assemble_installer.py
@@ -12,7 +12,11 @@ from string import Template
 # string to use latest eval on Hydra
 # TODO: using an empty string is not the cleanest
 # TODO: print script usage
-eval_id = sys.argv[1]
+# TODO: argparse or something
+if len(sys.argv) < 2:
+    eval_id = None
+else:
+    eval_id = sys.argv[1]
 
 response = requests.get('https://hydra.nixos.org/jobset/experimental-nix-installer/experimental-installer/evals', headers={'Accept': 'application/json'})
 evals = response.json()['evals']


### PR DESCRIPTION
Since it isn't quoted, the default value "" for testing_hydra_eval_id gets swallowed.

Handle no args in assemble_installer.py as well just to be less lazy.