### PR TITLE
clean up Determinate refs in help/usage messages

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -20,9 +20,9 @@ pub trait CommandExecute {
 }
 
 /**
-The Determinate Nix installer
+Experimental Nix Installer
 
-A fast, friendly, and reliable tool to help you use Nix with Flakes everywhere.
+A WIP replacement for the shell-based Nix installer (TODO: better description)
 */
 #[derive(Debug, Parser)]
 #[clap(version)]


### PR DESCRIPTION
It looks like the clap CLI framework pulls this in from a comment instead of from Cargo.toml as we'd expected.