### PR TITLE
Consistently find `nix` binaries in installer tarball

### DIFF
--- a/src/action/common/configure_nix.rs
+++ b/src/action/common/configure_nix.rs
@@ -89,10 +89,15 @@ impl ConfigureNix {
                     // If we are curing, the user may have multiple of these installed
                     if let Some(_existing) = found_nix_pkg {
                         return Err(Self::error(ConfigureNixError::MultipleNixPackages))?;
-                    } else {
-                        found_nix_pkg = Some(path);
                     }
-                    break;
+
+                    // Ensure we don't pick up any of the split components introduced in Nix 2.29
+                    // (or any other path happened to be named `nix`...)
+                    let subpath = path.join("bin/nix");
+                    if subpath.exists() {
+                        found_nix_pkg = Some(path);
+                        break;
+                    }
                 },
                 Err(_) => continue, /* Ignore it */
             };


### PR DESCRIPTION
##### Description

Fixes https://github.com/NixOS/experimental-nix-installer/issues/47

Previously, the installer made the assumption that paths matched by
`nix-*` would contain the Nix binaries. This was a mostly safe bet up
until Nix 2.29, where there are now multiple `nix-*` store paths for
each component that can be matched

Now, the installer will actually check each possible store path for the
main `nix` binary before marking it as the found package path

##### Checklist

- [x] Formatted with `cargo fmt`
- [ ] Built with `nix build`
- [ ] Ran flake checks with `nix flake check`
- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)
