### PR TITLE
cli: remove `term` crate dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,7 +1114,6 @@ dependencies = [
  "tar",
  "target-lexicon",
  "tempfile",
- "term",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -1988,15 +1987,6 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "term"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2111ef44dae28680ae9752bb89409e7310ca33a8c621ebe7b106cf5c928b3ac0"
-dependencies = [
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,6 @@ typetag = { version = "0.2.17", default-features = false }
 dyn-clone = { version = "1.0.9", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = [ "std", "std_rng" ] }
 semver = { version = "1.0.23", default-features = false, features = ["serde", "std"] }
-term = { version = "1.0.0", default-features = false }
 uuid = { version = "1.2.2", features = ["serde"] }
 os-release = { version = "0.1.0", default-features = false }
 strum = { version = "0.26.1", features = ["derive"] }

--- a/src/cli/interaction.rs
+++ b/src/cli/interaction.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::io::{stdin, stdout, BufRead, Write};
 
 use eyre::{eyre, WrapErr};
@@ -11,26 +10,12 @@ pub enum PromptChoice {
     Explain,
 }
 
-// Do not try to get clever!
-//
-// Mac is extremely janky if you `curl $URL | sudo sh` and the TTY may not be set up right.
-// The below method was adopted from Rustup at https://github.com/rust-lang/rustup/blob/3331f34c01474bf216c99a1b1706725708833de1/src/cli/term2.rs#L37
 pub(crate) async fn prompt(
     question: impl AsRef<str>,
     default: PromptChoice,
     currently_explaining: bool,
 ) -> eyre::Result<PromptChoice> {
-    let stdout = stdout();
-    let terminfo = term::terminfo::TermInfo::from_env().unwrap_or_else(|_| {
-        tracing::warn!("Couldn't find terminfo, using empty fallback terminfo");
-        term::terminfo::TermInfo {
-            names: vec![],
-            bools: HashMap::new(),
-            numbers: HashMap::new(),
-            strings: HashMap::new(),
-        }
-    });
-    let mut term = term::terminfo::TerminfoTerminal::new_with_terminfo(stdout, terminfo);
+    let mut stdout = stdout();
     let with_confirm = format!(
         "\
         {question}\n\
@@ -65,8 +50,8 @@ pub(crate) async fn prompt(
         },
     );
 
-    term.write_all(with_confirm.as_bytes())?;
-    term.flush()?;
+    stdout.write_all(with_confirm.as_bytes())?;
+    stdout.flush()?;
 
     let input = read_line()?;
 


### PR DESCRIPTION
 Remove `term` crate dependency.

 The comment makes me a little hesitant to remove,
 but I couldn't find any actual special handling that the `TermInfo`
 brought, so I think it should be safe.

This should be manually tested on a darwin machine.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)
