### PR TITLE
build: Remove unused `once_cell` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,6 @@ dependencies = [
  "indexmap 2.13.0",
  "nix",
  "nix-config-parser",
- "once_cell",
  "os-release",
  "owo-colors",
  "plist",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ which = "6.0.0"
 sysctl = "0.7.1"
 walkdir = "2.3.3"
 indexmap = { version = "2.13.0", features = ["serde"] }
-once_cell = "1.19.0"
 tempfile = "3.24.0"
 
 [dev-dependencies]


### PR DESCRIPTION
##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)
