### PR TITLE
chore: Bump `nixpkgs`; Drop `checkpolicy` overlay

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -169,28 +169,15 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1756178832,
-        "narHash": "sha256-O2CIn7HjZwEGqBrwu9EU76zlmA5dbmna7jL1XUmAId8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d98ce345cdab58477ca61855540999c86577d19d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d98ce345cdab58477ca61855540999c86577d19d",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "crane": "crane",
         "flake-compat": "flake-compat",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nix",
+          "nixpkgs"
+        ]
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,16 +2,11 @@
   description = "Experimental Nix Installer";
 
   inputs = {
-    # can track upstream versioning with
-    # git show $most_recently_merged_commit:flake.lock | jq '.nodes[.nodes.root.inputs.nixpkgs].locked.rev'
-    nixpkgs.url = "github:NixOS/nixpkgs/d98ce345cdab58477ca61855540999c86577d19d";
+    nixpkgs.follows = "nix/nixpkgs";
 
     crane.url = "github:ipetkov/crane/v0.20.0";
 
-    nix = {
-      url = "github:NixOS/nix/2.33.1";
-      # Omitting `inputs.nixpkgs.follows = "nixpkgs";` on purpose
-    };
+    nix.url = "github:NixOS/nix/2.33.1";
 
     flake-compat.url = "github:edolstra/flake-compat/v1.0.0";
   };


### PR DESCRIPTION
- **nix: Remove obsolete `checkpolicy` overlay**
- **chore: Update `nixpkgs`**

This bumps the `nixpkgs` to the version used in the `Nix` input.
I didn't follow that input, because of the comment.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)
