### PR TITLE
tests: replace EOL Ubuntu versions with 24.04

### DIFF
--- a/nix/tests/container-test/default.nix
+++ b/nix/tests/container-test/default.nix
@@ -15,21 +15,11 @@ let
       system = "x86_64-linux";
     };
 
-    # focal
-    "ubuntu-v20_04" = {
+    # Noble
+    "ubuntu-v24_04" = {
       tarball = builtins.fetchurl {
-        url = "http://cdimage.ubuntu.com/ubuntu-base/releases/20.04/release/ubuntu-base-20.04.1-base-amd64.tar.gz";
-        sha256 = "0ryn38csmx41a415g9b3wk30csaxxlkgkdij9v4754pk877wpxlp";
-      };
-      tester = ./default/Dockerfile;
-      system = "x86_64-linux";
-    };
-
-    # bionic
-    "ubuntu-v18_04" = {
-      tarball = builtins.fetchurl {
-        url = "http://cdimage.ubuntu.com/ubuntu-base/releases/18.04/release/ubuntu-base-18.04.5-base-amd64.tar.gz";
-        sha256 = "1sh73pqwgyzkyssv3ngpxa2ynnkbdvjpxdw1v9ql4ghjpd3hpwlg";
+        url = "http://cdimage.ubuntu.com/ubuntu-base/releases/24.04/release/ubuntu-base-24.04.3-base-amd64.tar.gz";
+        sha256 = "1ybl31qj4ixyxi89h80gh71mpllnkqklbyj6pfrqil0ajgiwvhkb";
       };
       tester = ./default/Dockerfile;
       system = "x86_64-linux";

--- a/nix/tests/vm-test/default.nix
+++ b/nix/tests/vm-test/default.nix
@@ -329,21 +329,21 @@ let
   images = {
 
     # End of standard support https://wiki.ubuntu.com/Releases
-    "ubuntu-v16_04" = {
-      image = import <nix/fetchurl.nix> {
-        url = "https://app.vagrantup.com/generic/boxes/ubuntu1604/versions/4.1.12/providers/libvirt.box";
-        hash = "sha256-lO4oYQR2tCh5auxAYe6bPOgEqOgv3Y3GC1QM1tEEEU8=";
-      };
-      rootDisk = "box.img";
-      system = "x86_64-linux";
-    };
-
     "ubuntu-v22_04" = {
       image = import <nix/fetchurl.nix> {
         url = "https://app.vagrantup.com/generic/boxes/ubuntu2204/versions/4.1.12/providers/libvirt.box";
         hash = "sha256-HNll0Qikw/xGIcogni5lz01vUv+R3o8xowP2EtqjuUQ=";
       };
       rootDisk = "box.img";
+      system = "x86_64-linux";
+    };
+
+    "ubuntu-v24_04" = {
+      image = import <nix/fetchurl.nix> {
+        url = "https://vagrantcloud.com/bento/boxes/ubuntu-24.04/versions/202502.21.0/providers/libvirt/amd64/vagrant.box";
+        hash = "sha256-nXerG+g7DG2EszsczaOeVMkbpPOTXGKa+KdYHvF9jq8=";
+      };
+      rootDisk = "box_0.img";
       system = "x86_64-linux";
     };
 


### PR DESCRIPTION
Remove Ubuntu 16.04, 18.04, and 20.04 which have reached end of standard support. Add Ubuntu 24.04 (Noble) which is supported until April 2029.

VM tests: 16.04 -> 24.04
Container tests: 18.04, 20.04 -> 24.04

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)
