### PR TITLE
build: Enable link time optimization (lto)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,4 @@ eyre = { version = "0.6.8", default-features = false, features = [
 [profile.release]
 strip = true    # Automatically strip symbols from the binary.
 opt-level = "z" # Optimize for size.
-
-# Disabled for now while we are in experimental phase
-# This gives maybe 10% smaller binaries but increases compile time significantly.
-# lto = true
+lto = true


### PR DESCRIPTION
Since we are nearing the end of the experimental phase we can enable
`lto` again.

Because we embed the nix binary the gains are not quite 10%, rather 6.5%,
from `33MiB` -> `31MiB`

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)
