### PR TITLE
manifest: Remove explicit resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "nix-installer"
 description = "Experimental Nix Installer"
 version = "2.33.2"
 edition = "2024"
-resolver = "2"
 license = "LGPL-2.1"
 repository = "https://github.com/NixOS/nix-installer"
 


### PR DESCRIPTION
The resolver has been on the version `2` by default since the `2021` version.
Remove the explicit setting, so that we can take advantage of future
resolver improvements.

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)
