### PR TITLE
Update help text

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,9 +29,9 @@ pub trait CommandExecute {
 }
 
 /**
-Experimental Nix Installer
+Nix Installer
 
-A WIP replacement for the shell-based Nix installer (TODO: better description)
+A tool to install Nix or manage an existing installation.
 */
 #[derive(Debug, Parser)]
 #[clap(version)]


### PR DESCRIPTION
The installer is no longer WIP. Update help to say:
```
Nix Installer

A tool to install Nix or manage an existing installation.

Usage: nix-installer [OPTIONS] <COMMAND>
...
```