### PR TITLE
release: publish SHA256SUMS alongside binaries

### DIFF
--- a/.github/workflows/release-script.yml
+++ b/.github/workflows/release-script.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   create-draft-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release create
+      id-token: write # Sigstore OIDC token for attestation
+      attestations: write # upload to attestation registry
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -23,6 +27,13 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - name: Create draft release
         # The script also depends on gh and git but those are both pre-installed on the runner
-        run: nix run --inputs-from .# nixpkgs#python3 -- scripts/assemble_installer.py "${{ github.event.inputs.testing_hydra_eval_id }}"
+        run: nix run --inputs-from .# nixpkgs#python3 -- scripts/assemble_installer.py --out-dir release-artifacts "${{ github.event.inputs.testing_hydra_eval_id }}"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Attest release artifacts
+        # Binaries are realised from cache.nixos.org via nix-store -r,
+        # which verifies the NAR signature against cache.nixos.org-1.
+        # The attestation proves this workflow released exactly these bytes.
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: release-artifacts/*

--- a/scripts/assemble_installer.py
+++ b/scripts/assemble_installer.py
@@ -2,6 +2,7 @@
 """Assemble and release nix-installer binaries from Hydra builds."""
 
 import argparse
+import hashlib
 import json
 import os
 import shutil
@@ -179,6 +180,16 @@ def main() -> None:
     with open(substituted_file, "w", encoding="utf-8") as output_file:
         output_file.write(updated_content)
     release_files.append(substituted_file)
+
+    # Write SHA256SUMS in the format sha256sum -c expects.
+    # Gives users a low-tech verification path that does not require gh,
+    # and the file itself is covered by the attestation.
+    sums_file = f"{out_dir}/SHA256SUMS"
+    with open(sums_file, "w", encoding="utf-8") as f:
+        for path in release_files:
+            digest = hashlib.sha256(open(path, "rb").read()).hexdigest()
+            f.write(f"{digest}  {os.path.basename(path)}\n")
+    release_files.append(sums_file)
 
     # Create the GitHub release
     create_release(version, release_files)

--- a/scripts/assemble_installer.py
+++ b/scripts/assemble_installer.py
@@ -3,10 +3,10 @@
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
-import tempfile
 import tomllib
 import urllib.request
 from string import Template
@@ -113,6 +113,11 @@ def main() -> None:
         default=None,
         help="Hydra evaluation ID to use (defaults to latest matching HEAD)",
     )
+    parser.add_argument(
+        "--out-dir",
+        default="release-artifacts",
+        help="Directory to write release artifacts (kept for attestation)",
+    )
     args = parser.parse_args()
 
     # Fetch and select the evaluation
@@ -145,35 +150,38 @@ def main() -> None:
     # Get version from Cargo.toml
     version = get_version()
 
-    # Create release with all installer binaries
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        release_files: list[str] = []
+    # Create release with all installer binaries.
+    # Artifacts are written to a persistent directory so the workflow
+    # can generate build provenance attestations after upload.
+    out_dir = args.out_dir
+    os.makedirs(out_dir, exist_ok=True)
+    release_files: list[str] = []
 
-        # Copy installer binaries
-        for installer_url, system in installers:
-            installer_file = f"{tmpdirname}/nix-installer-{system}"
-            release_files.append(installer_file)
-            print(f"Copying {installer_url} to {installer_file}")
-            shutil.copy(f"{installer_url}/bin/nix-installer", installer_file)
+    # Copy installer binaries
+    for installer_url, system in installers:
+        installer_file = f"{out_dir}/nix-installer-{system}"
+        release_files.append(installer_file)
+        print(f"Copying {installer_url} to {installer_file}")
+        shutil.copy(f"{installer_url}/bin/nix-installer", installer_file)
 
-        # Substitute version in nix-installer.sh
-        original_file = "nix-installer.sh"
-        with open(original_file, "r") as nix_installer_sh:
-            nix_installer_sh_contents = nix_installer_sh.read()
+    # Substitute version in nix-installer.sh
+    original_file = "nix-installer.sh"
+    with open(original_file, "r") as nix_installer_sh:
+        nix_installer_sh_contents = nix_installer_sh.read()
 
-        template = Template(nix_installer_sh_contents)
-        updated_content = template.safe_substitute(
-            assemble_installer_templated_version=version
-        )
+    template = Template(nix_installer_sh_contents)
+    updated_content = template.safe_substitute(
+        assemble_installer_templated_version=version
+    )
 
-        # Write the modified content to the output file
-        substituted_file = f"{tmpdirname}/nix-installer.sh"
-        with open(substituted_file, "w", encoding="utf-8") as output_file:
-            output_file.write(updated_content)
-        release_files.append(substituted_file)
+    # Write the modified content to the output file
+    substituted_file = f"{out_dir}/nix-installer.sh"
+    with open(substituted_file, "w", encoding="utf-8") as output_file:
+        output_file.write(updated_content)
+    release_files.append(substituted_file)
 
-        # Create the GitHub release
-        create_release(version, release_files)
+    # Create the GitHub release
+    create_release(version, release_files)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Description

Publishes a `SHA256SUMS` file with each release so users without the `gh` CLI can run `sha256sum -c` to catch truncated or corrupted downloads. The file is written into the same `release-artifacts/` directory as the binaries, so it is also covered by the build provenance attestation added in #176 — verify `SHA256SUMS` once with `gh attestation verify`, then check any binary against it with coreutils alone.

##### Checklist

- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)