### PR TITLE
macos: hide /nix from Finder and stop fseventsd journaling

### DIFF
--- a/src/action/macos/create_nix_volume.rs
+++ b/src/action/macos/create_nix_volume.rs
@@ -14,7 +14,7 @@ use std::{
 use tracing::{Span, span};
 
 use super::{
-    CreateVolumeService, DARWIN_LAUNCHD_DOMAIN, KickstartLaunchctlService,
+    CreateVolumeService, DARWIN_LAUNCHD_DOMAIN, KickstartLaunchctlService, SuppressVolumeIndexing,
     create_fstab_entry::CreateFstabEntry,
 };
 
@@ -39,6 +39,7 @@ pub struct CreateNixVolume {
     bootstrap_volume: StatefulAction<BootstrapLaunchctlService>,
     kickstart_launchctl_service: StatefulAction<KickstartLaunchctlService>,
     enable_ownership: StatefulAction<EnableOwnership>,
+    suppress_indexing: StatefulAction<SuppressVolumeIndexing>,
 }
 
 impl CreateNixVolume {
@@ -96,6 +97,7 @@ impl CreateNixVolume {
             KickstartLaunchctlService::plan(DARWIN_LAUNCHD_DOMAIN, NIX_VOLUME_MOUNTD_NAME)
                 .map_err(Self::error)?;
         let enable_ownership = EnableOwnership::plan("/nix").map_err(Self::error)?;
+        let suppress_indexing = SuppressVolumeIndexing::plan("/nix").map_err(Self::error)?;
 
         Ok(Self {
             disk: disk.to_path_buf(),
@@ -112,6 +114,7 @@ impl CreateNixVolume {
             bootstrap_volume,
             kickstart_launchctl_service,
             enable_ownership,
+            suppress_indexing,
         }
         .into())
     }
@@ -154,6 +157,7 @@ impl Action for CreateNixVolume {
         explanation.push(self.setup_volume_daemon.tracing_synopsis());
         explanation.push(self.bootstrap_volume.tracing_synopsis());
         explanation.push(self.enable_ownership.tracing_synopsis());
+        explanation.push(self.suppress_indexing.tracing_synopsis());
 
         vec![ActionDescription::new(self.tracing_synopsis(), explanation)]
     }
@@ -210,6 +214,7 @@ impl Action for CreateNixVolume {
         crate::action::macos::wait_for_nix_store_dir().map_err(Self::error)?;
 
         self.enable_ownership.try_execute().map_err(Self::error)?;
+        self.suppress_indexing.try_execute().map_err(Self::error)?;
 
         Ok(())
     }
@@ -228,6 +233,7 @@ impl Action for CreateNixVolume {
         explanation.push(self.setup_volume_daemon.tracing_synopsis());
         explanation.push(self.bootstrap_volume.tracing_synopsis());
         explanation.push(self.enable_ownership.tracing_synopsis());
+        explanation.push(self.suppress_indexing.tracing_synopsis());
 
         vec![ActionDescription::new(
             format!(
@@ -242,6 +248,10 @@ impl Action for CreateNixVolume {
     #[tracing::instrument(level = "debug", skip_all)]
     fn revert(&mut self) -> Result<(), ActionError> {
         let mut errors = vec![];
+
+        if let Err(err) = self.suppress_indexing.try_revert() {
+            errors.push(err);
+        }
 
         if let Err(err) = self.enable_ownership.try_revert() {
             errors.push(err);

--- a/src/action/macos/mod.rs
+++ b/src/action/macos/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod encrypt_apfs_volume;
 pub(crate) mod kickstart_launchctl_service;
 pub(crate) mod set_tmutil_exclusion;
 pub(crate) mod set_tmutil_exclusions;
+pub(crate) mod suppress_volume_indexing;
 pub(crate) mod unmount_apfs_volume;
 
 use std::fs;
@@ -34,6 +35,7 @@ pub use kickstart_launchctl_service::KickstartLaunchctlService;
 use serde::Deserialize;
 pub use set_tmutil_exclusion::SetTmutilExclusion;
 pub use set_tmutil_exclusions::SetTmutilExclusions;
+pub use suppress_volume_indexing::SuppressVolumeIndexing;
 pub use unmount_apfs_volume::UnmountApfsVolume;
 
 use crate::execute_command;

--- a/src/action/macos/suppress_volume_indexing.rs
+++ b/src/action/macos/suppress_volume_indexing.rs
@@ -1,0 +1,122 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tracing::{Span, span};
+
+use crate::action::{
+    Action, ActionDescription, ActionError, ActionErrorKind, ActionTag, StatefulAction,
+};
+use crate::execute_command;
+
+/**
+Hide the Nix volume from Finder and stop fseventsd journaling on it.
+
+On large Nix stores (hundreds of thousands of entries), Finder and the
+system open/save panel XPC service enumerate `/nix/store` via the synthetic
+firmlink under `/` and cache one `_FileCache` + `NSURL` object per entry in
+`DesktopServicesPriv`, leaking on the order of a gigabyte of RSS and burning
+CPU re-syncing on every fsevent. The `nobrowse` fstab option hides the
+*volume* from the sidebar (and from Spotlight/mds), but not the firmlink
+directory entry under `/` that Finder walks.
+
+This action sets the BSD `UF_HIDDEN` flag on the mount point so directory
+enumeration in Finder/NSOpenPanel skips it, and drops the Apple-documented
+`.fseventsd/no_log` marker so fseventsd stops writing its event journal
+during builds and GC. Spotlight needs no extra marker: `nobrowse` already
+covers it, and `.metadata_never_index` is unreliable on recent macOS.
+ */
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone)]
+#[serde(tag = "action_name", rename = "suppress_volume_indexing")]
+pub struct SuppressVolumeIndexing {
+    mount_point: PathBuf,
+}
+
+impl SuppressVolumeIndexing {
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub fn plan(mount_point: impl AsRef<Path>) -> Result<StatefulAction<Self>, ActionError> {
+        Ok(Self {
+            mount_point: mount_point.as_ref().to_path_buf(),
+        }
+        .into())
+    }
+}
+
+#[typetag::serde(name = "suppress_volume_indexing")]
+impl Action for SuppressVolumeIndexing {
+    fn action_tag() -> ActionTag {
+        ActionTag("suppress_volume_indexing")
+    }
+    fn tracing_synopsis(&self) -> String {
+        format!(
+            "Hide `{}` from Finder and disable fseventsd journaling on it",
+            self.mount_point.display()
+        )
+    }
+
+    fn tracing_span(&self) -> Span {
+        span!(
+            tracing::Level::DEBUG,
+            "suppress_volume_indexing",
+            mount_point = %self.mount_point.display(),
+        )
+    }
+
+    fn execute_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(self.tracing_synopsis(), vec![])]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    fn execute(&mut self) -> Result<(), ActionError> {
+        let fseventsd_dir = self.mount_point.join(".fseventsd");
+        fs::create_dir_all(&fseventsd_dir)
+            .map_err(|e| ActionErrorKind::CreateDirectory(fseventsd_dir.clone(), e))
+            .map_err(Self::error)?;
+        let no_log = fseventsd_dir.join("no_log");
+        fs::write(&no_log, b"")
+            .map_err(|e| ActionErrorKind::Write(no_log, e))
+            .map_err(Self::error)?;
+
+        execute_command(
+            Command::new("/usr/bin/chflags")
+                .arg("hidden")
+                .arg(&self.mount_point)
+                .stdin(std::process::Stdio::null()),
+        )
+        .map_err(Self::error)?;
+
+        Ok(())
+    }
+
+    fn revert_description(&self) -> Vec<ActionDescription> {
+        vec![ActionDescription::new(
+            format!(
+                "Remove fseventsd opt-out marker and unhide `{}`",
+                self.mount_point.display()
+            ),
+            vec![],
+        )]
+    }
+
+    #[tracing::instrument(level = "debug", skip_all)]
+    fn revert(&mut self) -> Result<(), ActionError> {
+        // Best-effort: uninstall removes the volume anyway, so just log failures.
+        let no_log = self.mount_point.join(".fseventsd").join("no_log");
+        if let Err(err) = fs::remove_file(&no_log)
+            && err.kind() != std::io::ErrorKind::NotFound
+        {
+            tracing::warn!(?err, path = %no_log.display(), "Could not remove fseventsd opt-out marker");
+        }
+
+        if let Err(err) = execute_command(
+            Command::new("/usr/bin/chflags")
+                .arg("nohidden")
+                .arg(&self.mount_point)
+                .stdin(std::process::Stdio::null()),
+        ) {
+            tracing::warn!(?err, path = %self.mount_point.display(), "Could not clear hidden flag");
+        }
+
+        Ok(())
+    }
+}

--- a/tests/fixtures/macos/macos.json
+++ b/tests/fixtures/macos/macos.json
@@ -85,6 +85,13 @@
             "path": "/nix"
           },
           "state": "Completed"
+        },
+        "suppress_indexing": {
+          "action": {
+            "action_name": "suppress_volume_indexing",
+            "mount_point": "/nix"
+          },
+          "state": "Completed"
         }
       },
       "state": "Completed"


### PR DESCRIPTION
##### Description

On a mature Nix store (>500k entries), Finder and the system open/save panel
XPC service (`com.apple.appkit.xpc.openAndSavePanelService`) walk the `/nix`
synthetic firmlink whenever the user browses near `/` and cache one
`_FileCache` + `NSURL` object per store entry inside `DesktopServicesPriv`.
On a 700k-entry store this leaks ~950 MB RSS in Finder and ~900 MB in the
open-panel service, plus ~50 % CPU re-syncing
`TNode::SynchronizeChildren → getattrlistbulk` on every fsevent. The existing
fstab `nobrowse` option hides the *volume* from the sidebar (and from
Spotlight/mds), but not the firmlink directory entry under `/` that
DesktopServices enumerates.

Adds a `SuppressVolumeIndexing` action that, on the mounted `/nix` volume:

- runs `chflags hidden /nix` — sets `UF_HIDDEN` on the volume root inode so
  Finder/NSOpenPanel skip the firmlink in directory listings; flag persists
  across remounts. This is the load-bearing fix for the RSS leak.
- creates `/nix/.fseventsd/no_log` — Apple-documented per-volume fseventsd
  journal opt-out
  ([FSEvents Programming Guide][fsevents]); cuts write I/O during builds and
  GC.

Spotlight needs no extra marker: `nobrowse` (`MNT_DONTBROWSE`) already opts
the volume out of mds, and `.metadata_never_index` is undocumented and
reported unreliable on recent macOS, so it is intentionally not written.

Wired into `CreateNixVolume` after `enable_ownership` (volume mounted and
owned). Revert is best-effort since uninstall removes the volume anyway.

<details><summary>Evidence (heap / sample on a 700k-entry store)</summary>

```text
$ heap Finder
Physical footprint:         952.3M
  686422  219655040  320.0  _FileCache    CFType  CoreServicesInternal
  686673   65919792   96.0  NSURL         ObjC    CoreFoundation
 1609722  129541344   80.5  CFString      ObjC    CoreFoundation

$ lsof -p $(pgrep -x Finder) | grep DIR
Finder  ...  5r  DIR  ...  /nix/store

$ sample Finder 3 | grep -A3 SynchronizeChildren
  TNode::SynchronizeChildren
    TFSInfoSynchronizer::FetchChildren
      TFSIterator::NextRaw → _URLEnumeratorGetNextURL → getattrlistbulk
```

Object count tracks `ls /nix/store | wc -l`. Same signature in
`openAndSavePanelService`.
</details>

[fsevents]: https://developer.apple.com/library/archive/documentation/Darwin/Conceptual/FSEvents_ProgGuide/FileSystemEventSecurity/FileSystemEventSecurity.html

##### Checklist

- [x] Added or updated relevant tests — `tests/fixtures/macos/macos.json`
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [ ] Linked to related issues (leave unchecked if not applicable)
