### PR TITLE
fix: build and link system profile instead of per-user ones

### DIFF
--- a/src/action/base/setup_default_profile.rs
+++ b/src/action/base/setup_default_profile.rs
@@ -4,7 +4,6 @@ use std::process::Command;
 
 use crate::{
     action::{ActionError, ActionErrorKind, ActionTag, StatefulAction},
-    profile::WriteToDefaultProfile,
     set_env,
     settings::{nix_store_path, nix_version, nss_cacert_store_path},
 };
@@ -132,7 +131,7 @@ impl Action for SetupDefaultProfile {
             pkgs: &[&nix_pkg, &nss_ca_cert_pkg],
         };
         profile
-            .install_packages(WriteToDefaultProfile::WriteToDefault)
+            .install_packages()
             .map_err(SetupDefaultProfileError::NixProfile)
             .map_err(Self::error)?;
 

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -35,13 +35,6 @@ pub enum Error {
     Deserialization(#[from] serde_json::Error),
 }
 
-pub enum WriteToDefaultProfile {
-    WriteToDefault,
-
-    #[cfg(test)]
-    Isolated,
-}
-
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum BackendType {
     NixEnv,
@@ -57,7 +50,7 @@ pub(crate) struct Profile<'a> {
 }
 
 impl Profile<'_> {
-    pub(crate) fn install_packages(&self, to_default: WriteToDefaultProfile) -> Result<(), Error> {
+    pub(crate) fn install_packages(&self) -> Result<(), Error> {
         match get_profile_backend_type(self.profile) {
             Some(BackendType::NixProfile) => nixprofile::NixProfile {
                 nix_store_path: self.nix_store_path,
@@ -65,14 +58,14 @@ impl Profile<'_> {
                 profile: self.profile,
                 pkgs: self.pkgs,
             }
-            .install_packages(to_default),
+            .install_packages(),
             _ => nixenv::NixEnv {
                 nix_store_path: self.nix_store_path,
                 nss_ca_cert_path: self.nss_ca_cert_path,
                 profile: self.profile,
                 pkgs: self.pkgs,
             }
-            .install_packages(to_default),
+            .install_packages(),
         }
     }
 }

--- a/src/profile/nixenv/mod.rs
+++ b/src/profile/nixenv/mod.rs
@@ -13,10 +13,7 @@ pub(crate) struct NixEnv<'a> {
 }
 
 impl NixEnv<'_> {
-    pub(crate) fn install_packages(
-        &self,
-        to_default: super::WriteToDefaultProfile,
-    ) -> Result<(), super::Error> {
+    pub(crate) fn install_packages(&self) -> Result<(), super::Error> {
         self.validate_paths_can_cohabitate()?;
 
         let tmp = tempfile::tempdir().map_err(super::Error::CreateTempDir)?;
@@ -25,7 +22,7 @@ impl NixEnv<'_> {
         self.make_empty_profile(&temporary_profile)?;
 
         if let Ok(canon_profile) = self.profile.canonicalize() {
-            self.set_profile_to(Some(&temporary_profile), &canon_profile)?;
+            self.set_profile_to(&temporary_profile, &canon_profile)?;
         }
 
         let paths_by_pkg_output = self.collect_paths_by_package_output(&temporary_profile)?;
@@ -54,14 +51,8 @@ impl NixEnv<'_> {
             self.install_path(&temporary_profile, pkg)?;
         }
 
-        self.set_profile_to(
-            match to_default {
-                #[cfg(test)]
-                super::WriteToDefaultProfile::Isolated => Some(self.profile),
-                super::WriteToDefaultProfile::WriteToDefault => None,
-            },
-            &temporary_profile,
-        )?;
+        // Do not let NIX_PROFILE or HOME/.nix-profile redirect the system profile update.
+        self.set_profile_to(self.profile, &temporary_profile)?;
 
         Ok(())
     }
@@ -123,21 +114,14 @@ impl NixEnv<'_> {
         Ok(())
     }
 
-    fn set_profile_to(
-        &self,
-        profile: Option<&Path>,
-        canon_profile: &Path,
-    ) -> Result<(), super::Error> {
+    fn set_profile_to(&self, profile: &Path, canon_profile: &Path) -> Result<(), super::Error> {
         tracing::debug!("Duplicating the existing profile into the scratch profile");
 
         let mut cmd = std::process::Command::new(self.nix_store_path.join("bin/nix-env"));
 
         cmd.set_nix_options(self.nss_ca_cert_path)?;
-
-        if let Some(profile) = profile {
-            cmd.arg("--profile");
-            cmd.arg(profile);
-        }
+        cmd.arg("--profile");
+        cmd.arg(profile);
 
         let output = cmd.arg("--set").arg(canon_profile).output().map_err(|e| {
             super::Error::StartNixCommand(

--- a/src/profile/nixenv/tests.rs
+++ b/src/profile/nixenv/tests.rs
@@ -1,8 +1,7 @@
 use std::io::Write;
-use std::os::unix::ffi::OsStringExt;
+use std::os::unix::{ffi::OsStringExt, fs::PermissionsExt};
 use std::path::{Path, PathBuf};
 
-use super::super::WriteToDefaultProfile;
 use super::NixCommandExt;
 use super::NixEnv;
 
@@ -68,6 +67,42 @@ fn sample_tree(dirname: &str, filename: &str, content: &str) -> PathBuf {
 }
 
 #[test]
+fn test_set_profile_to_is_explicit() {
+    let nix_store = tempfile::tempdir().unwrap();
+    let bin = nix_store.path().join("bin");
+    std::fs::create_dir(&bin).unwrap();
+
+    let nix_env = bin.join("nix-env");
+    std::fs::write(
+        &nix_env,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"${0%/*}/../args\"\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&nix_env).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&nix_env, permissions).unwrap();
+
+    let profile = nix_store.path().join("configured-profile");
+    let target = nix_store.path().join("target");
+    (NixEnv {
+        nix_store_path: nix_store.path(),
+        nss_ca_cert_path: nix_store.path(),
+        profile: &profile,
+        pkgs: &[],
+    })
+    .set_profile_to(&profile, &target)
+    .unwrap();
+
+    let args = std::fs::read_to_string(nix_store.path().join("args")).unwrap();
+    let expected = format!(
+        "--profile\n{}\n--set\n{}\n",
+        profile.display(),
+        target.display()
+    );
+    assert!(args.ends_with(&expected), "unexpected nix-env args: {args}");
+}
+
+#[test]
 fn test_detect_intersection() {
     if should_skip() {
         return;
@@ -85,7 +120,7 @@ fn test_detect_intersection() {
         profile: &profile_path,
         pkgs: &[&tree_1, &tree_2],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap_err();
 }
 
@@ -107,7 +142,7 @@ fn test_no_intersection() {
         profile: &profile_path,
         pkgs: &[&tree_1, &tree_2],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(
@@ -128,7 +163,7 @@ fn test_no_intersection() {
         profile: &profile_path,
         pkgs: &[&tree_3, &tree_4],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(
@@ -158,7 +193,7 @@ fn test_overlap_replaces() {
         profile: &profile_path,
         pkgs: &[&tree_base, &tree_1],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(
@@ -177,7 +212,7 @@ fn test_overlap_replaces() {
         profile: &profile_path,
         pkgs: &[&tree_2],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(
@@ -192,7 +227,7 @@ fn test_overlap_replaces() {
         profile: &profile_path,
         pkgs: &[&tree_3],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(

--- a/src/profile/nixprofile/mod.rs
+++ b/src/profile/nixprofile/mod.rs
@@ -13,10 +13,7 @@ pub(crate) struct NixProfile<'a> {
 }
 
 impl NixProfile<'_> {
-    pub(crate) fn install_packages(
-        &self,
-        to_default: super::WriteToDefaultProfile,
-    ) -> Result<(), super::Error> {
+    pub(crate) fn install_packages(&self) -> Result<(), super::Error> {
         self.validate_paths_can_cohabitate()?;
 
         let tmp = tempfile::tempdir().map_err(super::Error::CreateTempDir)?;
@@ -25,7 +22,7 @@ impl NixProfile<'_> {
         self.make_empty_profile(&temporary_profile)?;
 
         if let Ok(canon_profile) = self.profile.canonicalize() {
-            self.set_profile_to(Some(&temporary_profile), &canon_profile)?;
+            self.set_profile_to(&temporary_profile, &canon_profile)?;
         }
 
         let paths_by_pkg_output = self.collect_paths_by_package_output(&temporary_profile)?;
@@ -54,14 +51,8 @@ impl NixProfile<'_> {
             self.install_path(&temporary_profile, pkg)?;
         }
 
-        self.set_profile_to(
-            match to_default {
-                #[cfg(test)]
-                super::WriteToDefaultProfile::Isolated => Some(self.profile),
-                super::WriteToDefaultProfile::WriteToDefault => None,
-            },
-            &temporary_profile,
-        )?;
+        // Do not let NIX_PROFILE or HOME/.nix-profile redirect the system profile update.
+        self.set_profile_to(self.profile, &temporary_profile)?;
 
         Ok(())
     }
@@ -123,21 +114,14 @@ impl NixProfile<'_> {
         Ok(())
     }
 
-    fn set_profile_to(
-        &self,
-        profile: Option<&Path>,
-        canon_profile: &Path,
-    ) -> Result<(), super::Error> {
+    fn set_profile_to(&self, profile: &Path, canon_profile: &Path) -> Result<(), super::Error> {
         tracing::debug!("Duplicating the existing profile into the scratch profile");
 
         let mut cmd = std::process::Command::new(self.nix_store_path.join("bin/nix-env"));
 
         cmd.set_nix_options(self.nss_ca_cert_path)?;
-
-        if let Some(profile) = profile {
-            cmd.arg("--profile");
-            cmd.arg(profile);
-        }
+        cmd.arg("--profile");
+        cmd.arg(profile);
 
         let output = cmd.arg("--set").arg(canon_profile).output().map_err(|e| {
             super::Error::StartNixCommand(

--- a/src/profile/nixprofile/tests.rs
+++ b/src/profile/nixprofile/tests.rs
@@ -1,8 +1,7 @@
 use std::io::Write;
-use std::os::unix::ffi::OsStringExt;
+use std::os::unix::{ffi::OsStringExt, fs::PermissionsExt};
 use std::path::{Path, PathBuf};
 
-use super::super::WriteToDefaultProfile;
 use super::NixCommandExt;
 use super::NixProfile;
 
@@ -68,6 +67,42 @@ fn sample_tree(dirname: &str, filename: &str, content: &str) -> PathBuf {
 }
 
 #[test]
+fn test_set_profile_to_is_explicit() {
+    let nix_store = tempfile::tempdir().unwrap();
+    let bin = nix_store.path().join("bin");
+    std::fs::create_dir(&bin).unwrap();
+
+    let nix_env = bin.join("nix-env");
+    std::fs::write(
+        &nix_env,
+        "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"${0%/*}/../args\"\n",
+    )
+    .unwrap();
+    let mut permissions = std::fs::metadata(&nix_env).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&nix_env, permissions).unwrap();
+
+    let profile = nix_store.path().join("configured-profile");
+    let target = nix_store.path().join("target");
+    (NixProfile {
+        nix_store_path: nix_store.path(),
+        nss_ca_cert_path: nix_store.path(),
+        profile: &profile,
+        pkgs: &[],
+    })
+    .set_profile_to(&profile, &target)
+    .unwrap();
+
+    let args = std::fs::read_to_string(nix_store.path().join("args")).unwrap();
+    let expected = format!(
+        "--profile\n{}\n--set\n{}\n",
+        profile.display(),
+        target.display()
+    );
+    assert!(args.ends_with(&expected), "unexpected nix-env args: {args}");
+}
+
+#[test]
 fn test_detect_intersection() {
     if should_skip() {
         return;
@@ -85,7 +120,7 @@ fn test_detect_intersection() {
         profile: &profile_path,
         pkgs: &[&tree_1, &tree_2],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap_err();
 }
 
@@ -107,7 +142,7 @@ fn test_no_intersection() {
         profile: &profile_path,
         pkgs: &[&tree_1, &tree_2],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(
@@ -128,7 +163,7 @@ fn test_no_intersection() {
         profile: &profile_path,
         pkgs: &[&tree_3, &tree_4],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(
@@ -158,7 +193,7 @@ fn test_overlap_replaces() {
         profile: &profile_path,
         pkgs: &[&tree_base, &tree_1],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(
@@ -177,7 +212,7 @@ fn test_overlap_replaces() {
         profile: &profile_path,
         pkgs: &[&tree_2],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(
@@ -192,7 +227,7 @@ fn test_overlap_replaces() {
         profile: &profile_path,
         pkgs: &[&tree_3],
     })
-    .install_packages(WriteToDefaultProfile::Isolated)
+    .install_packages()
     .unwrap();
 
     assert_eq!(


### PR DESCRIPTION
Close #204 

This PR/commit fixes a regression from commit e370fa4, where:

- `SetupDefaultProfile` declares `/nix/var/nix/profiles/default` as its destination at src/action/base/setup_default_profile.rs.

- Both `nix-env` and `nix profile` profile backends discard profile destination path on installation.

Nix then selects the profile from ambient `NIX_PROFILE`, `HOME`/`XDG_`, or an existing .nix-profile. It can therefore successfully update another profile while leaving a dangling symlink:

```text
  /nix/var/nix/profiles/default
    -> /nix/var/nix/profiles/per-user/root/profile
```

##### Description

<!---
Please include a short description of what your PR does and / or the motivation behind it
--->

##### Checklist

- [ ] Added or updated relevant tests (leave unchecked if not applicable)
- [ ] Added or updated relevant documentation (leave unchecked if not applicable)
- [x] Linked to related issues (leave unchecked if not applicable)
